### PR TITLE
Replace postcss-simple-extend with postcss-extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,22 +135,35 @@ $column: 200px;
 ### Extends
 
 ```css
-/* before */
+/* Before */
 
-@define-extend bg-green {
-	background: green;
+@define-extend black-color { 
+	color: black;
+}
+%right-align {
+	text-align: right;
+} 
+.a {
+	@extend black-color;
+} 
+.b {
+	@extend .a;
+}
+.c { 
+	@extend .b;
+	@extend %right-align;
 }
 
-.notice--clear {
-	@extend bg-green;
+/* After */
+
+.a, .b, .c {
+	color: black;
 }
-
-/* after */
-
-.notice--clear {
-	background: green;
+.c {
+	text-align: right;
 }
 ```
+More uses and examples for `@extend` can be found in [its own README](https://github.com/travco/postcss-extend#postcss-extend-).
 
 ### Imports
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var processors = [
 		defaults: {}
 	},
 	{
-		plugin: require('postcss-simple-extend'),
+		plugin: require('postcss-extend'),
 		namespace: 'extend',
 		defaults: {}
 	}

--- a/package.json
+++ b/package.json
@@ -1,55 +1,54 @@
 {
-	"name": "precss",
-	"version": "0.3.0",
-	"description": "Use Sass-like markup in your CSS",
-	"keywords": [
-		"postcss",
-		"css",
-		"postcss-plugin",
-		"sass",
-		"variables",
-		"conditionals",
-		"ifs",
-		"thens",
-		"elses",
-		"fors",
-		"nesteds",
-		"nestings",
-		"eaches",
-		"mixins",
-		"imports",
-		"extends",
-		"placeholders"
-	],
-	"author": "Jonathan Neal <jonathantneal@hotmail.com>",
-	"license": "CC0-1.0",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/jonathantneal/precss.git"
-	},
-	"bugs": {
-		"url": "https://github.com/jonathantneal/precss/issues"
-	},
-	"homepage": "https://github.com/jonathantneal/precss",
-	"dependencies": {
-		"postcss": "^4.1.16",
-		"postcss-advanced-variables": "0.0.4",
-		"postcss-color-function": "^1.3.2",
-		"postcss-import": "^6.2.0",
-		"postcss-media-minmax": "^1.2.0",
-		"postcss-mixins": "^0.4.0",
-		"postcss-nested": "^0.3.2",
-		"postcss-sass-extend": "0.0.1",
-		"postcss-simple-extend": "^0.3.2",
-		"postcss-simple-vars": "^0.3.0"
-	},
-	"devDependencies": {
-		"chai": "^3.2.0",
-		"gulp": "^3.9.0",
-		"gulp-eslint": "^0.15.0",
-		"gulp-mocha": "^2.1.3"
-	},
-	"scripts": {
-		"test": "gulp"
-	}
+  "name": "precss",
+  "version": "0.3.0",
+  "description": "Use Sass-like markup in your CSS",
+  "keywords": [
+    "postcss",
+    "css",
+    "postcss-plugin",
+    "sass",
+    "variables",
+    "conditionals",
+    "ifs",
+    "thens",
+    "elses",
+    "fors",
+    "nesteds",
+    "nestings",
+    "eaches",
+    "mixins",
+    "imports",
+    "extends",
+    "placeholders"
+  ],
+  "author": "Jonathan Neal <jonathantneal@hotmail.com>",
+  "license": "CC0-1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jonathantneal/precss.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jonathantneal/precss/issues"
+  },
+  "homepage": "https://github.com/jonathantneal/precss",
+  "dependencies": {
+    "postcss": "^4.1.16",
+    "postcss-advanced-variables": "0.0.4",
+    "postcss-color-function": "^1.3.2",
+    "postcss-extend": "^0.4.3",
+    "postcss-import": "^6.2.0",
+    "postcss-media-minmax": "^1.2.0",
+    "postcss-mixins": "^0.4.0",
+    "postcss-nested": "^0.3.2",
+    "postcss-simple-vars": "^0.3.0"
+  },
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "gulp": "^3.9.0",
+    "gulp-eslint": "^0.15.0",
+    "gulp-mocha": "^2.1.3"
+  },
+  "scripts": {
+    "test": "gulp"
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -298,27 +298,32 @@ describe('postcss-minmax', function() {
 	});
 });
 
-describe('postcss-sass-extend', function() {
-	it('supports extend', function (done) {
+describe('postcss-extend', function() {
+	it('supports @extend', function (done) {
 		test(
 			'@define-extend black-color { ' +
+				'color: black;' +
+			'} ' +
+			'%right-align { ' +
+				'text-align: right; ' +
+			'} ' +
+			'.a { ' +
+				'@extend black-color; ' +
+			'} ' +
+			'.b { ' +
+				'@extend .a; ' +
+			'} ' +
+			'.c { ' +
+				'@extend .b; ' +
+				'@extend %right-align; ' +
+			'} ',
+
+			'.a, .b, .c { ' +
 				'color: black; ' +
 			'} ' +
-			'.a { ' +
-				'@extend black-color; ' +
-			'} ' +
-			'.b { ' +
-				'@extend black-color; ' +
-			'}',
-
-			'.a,\n.b { ' +
-				'color: black;\n' +
-			'} ' +
-			'.a { ' +
-			'} ' +
-			'.b { ' +
-			'}',
-
+			'.c { ' +
+				'text-align: right; ' +
+			'} ',
 			{},
 
 			done


### PR DESCRIPTION
Judging by the slim test-suite I assumed you're just checking to see if the plugin is able to load and function, so I left in just the single example in the README as the test (wouldn't want documentation to be wrong).

Only real changes in the package.json (despite github derping on the diff):
``` 
- "postcss-sass-extend": "0.0.1",
- "postcss-simple-extend": "^0.3.2",
+ "postcss-extend": "^0.4.3",
```
since postcss-extend also covers the functionality of both.