### PR TITLE
postcss-scss is a syntax not a parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ grunt.loadNpmTasks('grunt-postcss');
 grunt.initConfig({
 	postcss: {
 		options: {
-			parser: require('postcss-scss'),
+			syntax: require('postcss-scss'),
 			processors: [
 				require('precss')({ /* options */ })
 			]


### PR DESCRIPTION
See https://github.com/postcss/postcss/#custom-syntaxes