### PR TITLE
Switch link syntax in the plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,21 +305,21 @@ grunt.initConfig({
 
 PreCSS blends Sass-like strength with W3C future-syntax superpower, powered by the following plugins (in this order):
 
-- [postcss-partial-import]: W3C and Sass-like imports
-- [postcss-mixins]: Sass-like mixins
-- [postcss-advanced-variables]: Sass-like variables and methods
-- [postcss-custom-selectors]: W3C custom selectors
-- [postcss-custom-media]: W3C custom media queries
-- [postcss-custom-properties]: W3C custom variables
-- [postcss-media-minmax]: W3C `<` `<=` `>=` `>` media queries
-- [postcss-color-function]: W3C color methods
-- [postcss-nesting]: W3C nested selectors
-- [postcss-nested]: Sass-like nested selectors
-- [postcss-atroot]: place rules back up to the root
-- [postcss-property-lookup]: reference other property values
-- [postcss-extend]: W3C and Sass-like extend methods
-- [postcss-selector-matches]: W3C multiple matches pseudo-classes
-- [postcss-selector-not]: W3C multiple not pseudo-classes
+- [postcss-partial-import](https://github.com/jonathantneal/postcss-partial-import): W3C and Sass-like imports
+- [postcss-mixins](https://github.com/postcss/postcss-mixins): Sass-like mixins
+- [postcss-advanced-variables](https://github.com/jonathantneal/postcss-advanced-variables): Sass-like variables and methods
+- [postcss-custom-selectors](https://github.com/postcss/postcss-custom-selectors): W3C custom selectors
+- [postcss-custom-media](https://github.com/postcss/postcss-custom-media): W3C custom media queries
+- [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties): W3C custom variables
+- [postcss-media-minmax](https://github.com/postcss/postcss-media-minmax): W3C `<` `<=` `>=` `>` media queries
+- [postcss-color-function](https://github.com/postcss/postcss-color-function): W3C color methods
+- [postcss-nesting](https://github.com/jonathantneal/postcss-nesting): W3C nested selectors
+- [postcss-nested](https://github.com/postcss/postcss-nested): Sass-like nested selectors
+- [postcss-atroot](https://github.com/OEvgeny/postcss-atroot): place rules back up to the root
+- [postcss-property-lookup](https://github.com/simonsmith/postcss-property-lookup): reference other property values
+- [postcss-extend](https://github.com/travco/postcss-extend): W3C and Sass-like extend methods
+- [postcss-selector-matches](https://github.com/postcss/postcss-selector-matches): W3C multiple matches pseudo-classes
+- [postcss-selector-not](https://github.com/postcss/postcss-selector-not): W3C multiple not pseudo-classes
 
 [Grunt PostCSS]: https://github.com/nDmitry/grunt-postcss
 [Gulp PostCSS]:  https://github.com/postcss/gulp-postcss
@@ -328,19 +328,3 @@ PreCSS blends Sass-like strength with W3C future-syntax superpower, powered by t
 [PreCSS]:        https://github.com/jonathantneal/precss
 [ci-img]:        https://travis-ci.org/jonathantneal/precss.svg
 [ci]:            https://travis-ci.org/jonathantneal/precss
-
-[postcss-advanced-variables]: https://github.com/jonathantneal/postcss-advanced-variables
-[postcss-custom-properties]:  https://github.com/postcss/postcss-custom-properties
-[postcss-custom-selectors]:   https://github.com/postcss/postcss-custom-selectors
-[postcss-selector-matches]:   https://github.com/postcss/postcss-selector-matches
-[postcss-property-lookup]:    https://github.com/simonsmith/postcss-property-lookup
-[postcss-color-function]:     https://github.com/postcss/postcss-color-function
-[postcss-partial-import]:     https://github.com/jonathantneal/postcss-partial-import
-[postcss-custom-media]:       https://github.com/postcss/postcss-custom-media
-[postcss-media-minmax]:       https://github.com/postcss/postcss-media-minmax
-[postcss-selector-not]:       https://github.com/postcss/postcss-selector-not
-[postcss-nesting]:            https://github.com/jonathantneal/postcss-nesting
-[postcss-atroot]:             https://github.com/OEvgeny/postcss-atroot
-[postcss-extend]:             https://github.com/travco/postcss-extend
-[postcss-mixins]:             https://github.com/postcss/postcss-mixins
-[postcss-nested]:             https://github.com/postcss/postcss-nested


### PR DESCRIPTION
For whatever reason, the bullet list shows up as a bunch of empty `li` elements right now on npm.  Switching to the more common link syntax should resolve that?