### PR TITLE
Add list of plugins to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ grunt.initConfig({
 });
 ```
 
+# Plugins
+
+PreCSS is powered by the following plugins (in this order):
+
+- [postcss-extend-rule](https://github.com/jonathantneal/postcss-extend-rule)
+- [postcss-advanced-variables](https://github.com/jonathantneal/postcss-advanced-variables)
+- [postcss-preset-env](https://github.com/jonathantneal/postcss-preset-env)
+- [postcss-atroot](https://github.com/OEvgeny/postcss-atroot)
+- [postcss-property-lookup](https://github.com/simonsmith/postcss-property-lookup)
+- [postcss-nested](https://github.com/postcss/postcss-nested)
+
 [npm-url]: https://www.npmjs.com/package/precss
 [npm-img]: https://img.shields.io/npm/v/precss.svg
 [cli-url]: https://travis-ci.org/jonathantneal/precss


### PR DESCRIPTION
I was confused when I visited the documentation and couldn't find any detailed documentation on what this plugin does.

Providing a list of plugin libraries in the readme gives people some direction on how to go find details without them having to read the source code.