### PR TITLE
Update postcss dependency to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "postcss": "^6.0.23",
+    "postcss": "^7.0.2",
     "postcss-advanced-variables": "^2.3.3",
     "postcss-atroot": "^0.1.3",
     "postcss-extend-rule": "^2.0.0",


### PR DESCRIPTION
This is to resolve an issue when using `precss` with `gatsby-plugin-postcss`, which now uses postcss v7.