### PR TITLE
Feature #127 add functionality to pass down plugin-specific options

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -32,7 +32,7 @@ module.exports = {
 			message: 'supports global { stage } usage ',
 			options: {
 				stage: false
-		}
+			}
 		},
 		'options:plugin-specific': {
 			message: 'supports passing grid and color-mod { options } to postcssPresetEnv only',
@@ -48,5 +48,16 @@ module.exports = {
 				}
 			}
 		},
+		'options:disabled': {
+			message: 'supports disabling plugins',
+			options: {
+				features: {
+					'color-mod-function': true,
+				},
+				'postcssAtroot': {
+					'disable': true
+				}
+			}
+		}
 	}
 };

--- a/.tape.js
+++ b/.tape.js
@@ -24,6 +24,29 @@ module.exports = {
 			options: {
 				stage: 4
 			}
+		},
+		'options': {
+			message: 'supports passing no { options }'
+		},
+		'options:global': {
+			message: 'supports global { stage } usage ',
+			options: {
+				stage: false
 		}
+		},
+		'options:plugin-specific': {
+			message: 'supports passing grid and color-mod { options } to postcssPresetEnv only',
+			options: {
+				'postcssPresetEnv': {
+					features: {
+						'color-mod-function': false,
+					},
+					'autoprefixer': {
+						'grid': 'autoplace'
+					}
+
+				}
+			}
+		},
 	}
 };

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ There are two ways to pass down options
 
 Options provided without a plugin name specification will get passed down to all plugins will get applied for all supporting plugins eg. `stage: 0`
 
-#### Example for PostCSS
+#### Example using PostCSS
 
 ```js
 import postcss from 'postcss';
@@ -151,7 +151,7 @@ postcss([
 
 To make sure only one plugin uses an option and to avoid [collision with other plugins](https://github.com/jonathantneal/precss/issues/127#issuecomment-481900242) you can pass settings to a specific plugin by using its name in camelCase e.g. `postcss-extend-rule` becomes `postcssExtendRule`
 
-#### Example for PostCSS
+#### Example using PostCSS
 
 ```js
 import postcss from 'postcss';
@@ -160,6 +160,24 @@ import precss from 'precss';
 postcss([
   precss({
     postcssPresetEnv: {autoprefixer: { grid: true } }
+  })
+]).process(YOUR_CSS);
+```
+
+### Disable a specific plugin
+
+If you don´t want to use a plugin entirely, you may pass down the option `disable: true` to the plugins specific namespace. (see [explaination above](#passing-an-option-to-only-one-plugin))
+
+
+#### Example using PostCSS
+
+```js
+import postcss from 'postcss';
+import precss from 'precss';
+
+postcss([
+  precss({
+    postcssAtroot: { disable: true }
   })
 ]).process(YOUR_CSS);
 ```

--- a/README.md
+++ b/README.md
@@ -126,6 +126,44 @@ grunt.initConfig({
 });
 ```
 
+## Options
+
+There are two ways to pass down options
+
+### Passing an option to all plugins
+
+Options provided without a plugin name specification will get passed down to all plugins will get applied for all supporting plugins eg. `stage: 0`
+
+#### Example for PostCSS
+
+```js
+import postcss from 'postcss';
+import precss from 'precss';
+
+postcss([
+  precss(
+    stage: 0,
+  )
+]).process(YOUR_CSS);
+```
+
+### Passing an option to only one plugin
+
+To make sure only one plugin uses an option and to avoid [collision with other plugins](https://github.com/jonathantneal/precss/issues/127#issuecomment-481900242) you can pass settings to a specific plugin by using its name in camelCase e.g. `postcss-extend-rule` becomes `postcssExtendRule`
+
+#### Example for PostCSS
+
+```js
+import postcss from 'postcss';
+import precss from 'precss';
+
+postcss([
+  precss({
+    postcssPresetEnv: {autoprefixer: { grid: true } }
+  })
+]).process(YOUR_CSS);
+```
+
 # Plugins
 
 PreCSS is powered by the following plugins (in this order):

--- a/src/index.js
+++ b/src/index.js
@@ -8,14 +8,18 @@ import postcssPresetEnv from 'postcss-preset-env';
 import postcssPropertyLookup from 'postcss-property-lookup';
 
 // plugin chain
-const plugins = [
+const pluginsObj = {
 	postcssExtendRule,
 	postcssAdvancedVariables,
 	postcssPresetEnv,
 	postcssAtroot,
 	postcssPropertyLookup,
 	postcssNested
-];
+};
+
+// split plugins into key/value
+const plugins = Object.values(pluginsObj);
+const pluginKeys = Object.keys(pluginsObj);
 
 // plugin
 export default postcss.plugin('precss', rawopts => {
@@ -24,7 +28,30 @@ export default postcss.plugin('precss', rawopts => {
 
 	// initialize all plugins
 	const initializedPlugins = plugins.map(
-		plugin => plugin(opts)
+		(plugin, key) => {
+
+			let optionNames = Object.keys(opts);
+			let currentPluginName = pluginKeys[key];
+
+			//check if options specify current plugin
+			if(optionNames.includes(currentPluginName) ) {
+
+				let pluginSpecificOptions = opts[currentPluginName];
+
+				//delete top-level option from opts
+				delete opts[currentPluginName];
+
+				//create new Object with all known options to top-level
+				let allPluginOpts = Object.assign({}, opts, pluginSpecificOptions );
+
+				//delete used-plugin key from opts
+				delete opts[key];
+
+				return plugin( allPluginOpts );
+			}
+			//default return all options for the plugin
+			return plugin(opts)
+		}
 	);
 
 	// process css with all plugins

--- a/src/index.js
+++ b/src/index.js
@@ -38,13 +38,20 @@ export default postcss.plugin('precss', rawopts => {
 
 				let pluginSpecificOptions = opts[currentPluginName];
 
+				// check if plugin should be disabled
+				if (typeof pluginSpecificOptions.disable !== 'undefined' &&
+					pluginSpecificOptions.disable === true) {
+					delete opts[key];
+					return function() {};
+				}
+
 				//delete top-level option from opts
 				delete opts[currentPluginName];
 
 				//create new Object with all known options to top-level
 				let allPluginOpts = Object.assign({}, opts, pluginSpecificOptions );
 
-				//delete used-plugin key from opts
+				//delete used-plugin key from opts (clean)
 				delete opts[key];
 
 				return plugin( allPluginOpts );

--- a/test/options.css
+++ b/test/options.css
@@ -1,0 +1,16 @@
+@custom-media --viewport-medium (width <= 50rem);
+@custom-selector :--heading h1, h2, h3, h4, h5, h6;
+
+:--heading {
+	--brand-red: color-mod(yellow blend(red 50%));
+  @media (--viewport-medium) {
+    margin-block: 0;
+  }
+}
+
+.autoplacement-example {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+    grid-gap: 20px;
+}

--- a/test/options.disabled.expect.css
+++ b/test/options.disabled.expect.css
@@ -1,6 +1,3 @@
-@custom-media --viewport-medium (width <= 50rem);
-@custom-selector :--heading h1, h2, h3, h4, h5, h6;
-
 .parent {
 	background: green;
   @at-root {
@@ -10,12 +7,17 @@
 	}
 }
 
-:--heading {
-	--brand-red: color-mod(yellow blend(red 50%));
-  @media (--viewport-medium) {
-    margin-block: 0;
-  }
+h1,h2,h3,h4,h5,h6 {
+	--brand-red: rgb(255, 128, 0)
 }
+
+@media (max-width: 50rem) {
+
+h1,h2,h3,h4,h5,h6 {
+    margin-top: 0;
+    margin-bottom: 0
+}
+  }
 
 .autoplacement-example {
     display: grid;

--- a/test/options.expect.css
+++ b/test/options.expect.css
@@ -1,0 +1,18 @@
+h1,h2,h3,h4,h5,h6 {
+	--brand-red: color-mod(yellow blend(red 50%))
+}
+
+@media (max-width: 50rem) {
+
+h1,h2,h3,h4,h5,h6 {
+    margin-top: 0;
+    margin-bottom: 0
+}
+  }
+
+.autoplacement-example {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+    grid-gap: 20px;
+}

--- a/test/options.expect.css
+++ b/test/options.expect.css
@@ -1,3 +1,12 @@
+
+    .child {
+			color: red;
+  	}
+
+.parent {
+	background: green
+}
+
 h1,h2,h3,h4,h5,h6 {
 	--brand-red: color-mod(yellow blend(red 50%))
 }

--- a/test/options.global.expect.css
+++ b/test/options.global.expect.css
@@ -1,6 +1,14 @@
 @custom-media --viewport-medium (width <= 50rem);
 @custom-selector :--heading h1, h2, h3, h4, h5, h6;
 
+.child {
+			color: red;
+  	}
+
+.parent {
+	background: green
+}
+
 :--heading {
 	--brand-red: color-mod(yellow blend(red 50%));
 }

--- a/test/options.global.expect.css
+++ b/test/options.global.expect.css
@@ -1,0 +1,20 @@
+@custom-media --viewport-medium (width <= 50rem);
+@custom-selector :--heading h1, h2, h3, h4, h5, h6;
+
+:--heading {
+	--brand-red: color-mod(yellow blend(red 50%));
+}
+
+@media (--viewport-medium) {
+
+:--heading {
+    margin-block: 0
+}
+  }
+
+.autoplacement-example {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+    grid-gap: 20px;
+}

--- a/test/options.plugin-specific.expect.css
+++ b/test/options.plugin-specific.expect.css
@@ -1,3 +1,12 @@
+
+    .child {
+			color: red;
+  	}
+
+.parent {
+	background: green
+}
+
 h1,h2,h3,h4,h5,h6 {
 	--brand-red: color-mod(yellow blend(red 50%))
 }
@@ -21,21 +30,21 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 .autoplacement-example > *:nth-child(1) {
-	-ms-grid-row: 1;
-	-ms-grid-column: 1;
+			-ms-grid-row: 1;
+			-ms-grid-column: 1;
 }
 
 .autoplacement-example > *:nth-child(2) {
-	-ms-grid-row: 1;
-	-ms-grid-column: 3;
+			-ms-grid-row: 1;
+			-ms-grid-column: 3;
 }
 
 .autoplacement-example > *:nth-child(3) {
-	-ms-grid-row: 3;
-	-ms-grid-column: 1;
+			-ms-grid-row: 3;
+			-ms-grid-column: 1;
 }
 
 .autoplacement-example > *:nth-child(4) {
-	-ms-grid-row: 3;
-	-ms-grid-column: 3;
+			-ms-grid-row: 3;
+			-ms-grid-column: 3;
 }

--- a/test/options.plugin-specific.expect.css
+++ b/test/options.plugin-specific.expect.css
@@ -1,0 +1,41 @@
+h1,h2,h3,h4,h5,h6 {
+	--brand-red: color-mod(yellow blend(red 50%))
+}
+
+@media (max-width: 50rem) {
+
+h1,h2,h3,h4,h5,h6 {
+    margin-top: 0;
+    margin-bottom: 0
+}
+  }
+
+.autoplacement-example {
+    display: -ms-grid;
+    display: grid;
+    -ms-grid-columns: 1fr 20px 1fr;
+    grid-template-columns: 1fr 1fr;
+    -ms-grid-rows: auto 20px auto;
+    grid-template-rows: auto auto;
+    grid-gap: 20px;
+}
+
+.autoplacement-example > *:nth-child(1) {
+	-ms-grid-row: 1;
+	-ms-grid-column: 1;
+}
+
+.autoplacement-example > *:nth-child(2) {
+	-ms-grid-row: 1;
+	-ms-grid-column: 3;
+}
+
+.autoplacement-example > *:nth-child(3) {
+	-ms-grid-row: 3;
+	-ms-grid-column: 1;
+}
+
+.autoplacement-example > *:nth-child(4) {
+	-ms-grid-row: 3;
+	-ms-grid-column: 3;
+}


### PR DESCRIPTION
Hi there,

Issue #127 described the need for plugin specific options.
While it is possible to pass down options to **all** plugins, this isn´t optimal.
In my suggested solution the plugin name can be used to specify an option and applying it only where it is needed/wanted.
In my research of implementing this feature, I found this _outdated_ [Options Wiki Page](https://github.com/jonathantneal/precss/wiki/Options). Looking at the extent of the old implementation I can see why this feature was dropped.

However I still think it is important to have so I scaled it down while trying to keep as much of the current structure as possible.

## To-dos

- [X] Add Tests
- [X] Implement feature to pass down plugin-specific options
- [X] Update Readme
- [x]  Add `disable: true` option to disable a specific plugin completely // should this be added as a separate feature later on ?
- [ ] optimize code
<del>- [ ] the whole project version management stuff // is this part of a PR?</del>
<del>- [ ] update changelog </del>
